### PR TITLE
Changes to support displaying temperature for the current hour.

### DIFF
--- a/src/Drizzle.Models/WeatherModel.cs
+++ b/src/Drizzle.Models/WeatherModel.cs
@@ -91,5 +91,8 @@ namespace Drizzle.Models
 
         [ObservableProperty]
         private string pressureUnit;
+
+        public float CurrentHourlyTemp => HourlyTemp[DateTime.Now.Hour];
+        public float CurrentFeelsLikeTemp => CurrentHourlyTemp + (FeelsLike-Temperature);
     }
 }

--- a/src/Drizzle.UI.UWP/Views/MainPage.xaml
+++ b/src/Drizzle.UI.UWP/Views/MainPage.xaml
@@ -147,7 +147,7 @@
                     HorizontalAlignment="Center"
                     FontSize="34"
                     HorizontalTextAlignment="Center">
-                    <Run Text="{x:Bind shellVm.SelectedWeather.Temperature, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:F0}'}" />
+                    <Run Text="{x:Bind shellVm.SelectedWeather.CurrentHourlyTemp, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:F0}'}" />
                     <Run Text="{x:Bind shellVm.SelectedWeather.TemperatureUnit, Mode=OneWay}" />
                 </TextBlock>
                 <StackPanel HorizontalAlignment="Center" Spacing="2">
@@ -160,7 +160,7 @@
                         Opacity="0.4"
                         Style="{StaticResource BodyTextBlockStyle}">
                         <Run x:Uid="FeelsLikeTemperature" />
-                        <Run Text="{x:Bind shellVm.SelectedWeather.FeelsLike, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:F0}'}" />
+                        <Run Text="{x:Bind shellVm.SelectedWeather.CurrentFeelsLikeTemp, Mode=OneWay, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:F0}'}" />
                         <Run Text="{x:Bind shellVm.SelectedWeather.TemperatureUnit, Mode=OneWay}" />
                     </TextBlock>
                 </StackPanel>


### PR DESCRIPTION
- Created two new props on the `WeatherData` model.
  - `CurrentHourlyTemp`
  - `CurrentFeelsLikeTemp`
- Set main window to use the new properties.

In response to https://github.com/rocksdanister/weather/issues/13