### PR TITLE
Fix ListViewItem style incorrect on windows 10

### DIFF
--- a/src/Drizzle.UI.UWP/App.xaml
+++ b/src/Drizzle.UI.UWP/App.xaml
@@ -712,6 +712,609 @@
                 </Setter>
             </Style>
 
+            <Style x:Key="ListViewItemStyle" TargetType="ListViewItem">
+                <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}" />
+                <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}" />
+                <Setter Property="BorderBrush" Value="{x:Null}" />
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
+                <Setter Property="TabNavigation" Value="Local" />
+                <Setter Property="IsHoldingEnabled" Value="True" />
+                <Setter Property="Padding" Value="12,0,12,0" />
+                <Setter Property="Margin" Value="4,2" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="VerticalContentAlignment" Value="Center" />
+                <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}" />
+                <Setter Property="MinHeight" Value="{ThemeResource ListViewItemMinHeight}" />
+                <Setter Property="MaxWidth" Value="1224" />
+                <Setter Property="AllowDrop" Value="False" />
+                <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
+                <Setter Property="FocusVisualMargin" Value="0" />
+                <Setter Property="CornerRadius" Value="4" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="ListViewItem">
+                            <Grid
+                                x:Name="ContentBorder"
+                                Background="{TemplateBinding Background}"
+                                BorderBrush="{TemplateBinding BorderBrush}"
+                                BorderThickness="{TemplateBinding BorderThickness}"
+                                Control.IsTemplateFocusTarget="True"
+                                CornerRadius="{TemplateBinding CornerRadius}"
+                                FocusVisualMargin="{TemplateBinding FocusVisualMargin}"
+                                RenderTransformOrigin="0.5,0.5">
+                                <Grid.RenderTransform>
+                                    <ScaleTransform x:Name="ContentBorderScale" />
+                                </Grid.RenderTransform>
+
+                                <Border
+                                    x:Name="BorderBackground"
+                                    Margin="0"
+                                    Background="{ThemeResource SystemAccentColorDark1}"
+                                    Control.IsTemplateFocusTarget="True"
+                                    CornerRadius="{TemplateBinding CornerRadius}"
+                                    IsHitTestVisible="False"
+                                    Opacity="0" />
+                                <Border
+                                    x:Name="BorderSelected"
+                                    Width="4"
+                                    Margin="0,12"
+                                    HorizontalAlignment="Left"
+                                    Background="Transparent"
+                                    Control.IsTemplateFocusTarget="True"
+                                    CornerRadius="2"
+                                    IsHitTestVisible="False" />
+
+                                <Grid
+                                    x:Name="ContentPresenterGrid"
+                                    Margin="0,0,0,0"
+                                    Background="Transparent">
+                                    <Grid.RenderTransform>
+                                        <TranslateTransform x:Name="ContentPresenterTranslateTransform" />
+                                    </Grid.RenderTransform>
+                                    <ContentPresenter
+                                        x:Name="ContentPresenter"
+                                        Margin="{TemplateBinding Padding}"
+                                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                        Content="{TemplateBinding Content}"
+                                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                                        ContentTransitions="{TemplateBinding ContentTransitions}" />
+
+                                </Grid>
+                                <!--
+                                    The 'Xg' text simulates the amount of space one line of text will occupy.
+                                    In the DataPlaceholder state, the Content is not loaded yet so we
+                                    approximate the size of the item using placeholder text.
+                                -->
+                                <TextBlock
+                                    x:Name="PlaceholderTextBlock"
+                                    Margin="{TemplateBinding Padding}"
+                                    AutomationProperties.AccessibilityView="Raw"
+                                    Foreground="{x:Null}"
+                                    IsHitTestVisible="False"
+                                    Opacity="0"
+                                    Text="Xg" />
+                                <Rectangle
+                                    x:Name="PlaceholderRect"
+                                    Fill="{ThemeResource ListViewItemPlaceholderBackground}"
+                                    Visibility="Collapsed" />
+                                <Border
+                                    x:Name="MultiSelectSquare"
+                                    Width="20"
+                                    Height="20"
+                                    Margin="12,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    BorderBrush="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+                                    BorderThickness="2"
+                                    Visibility="Collapsed">
+                                    <Border.Clip>
+                                        <RectangleGeometry Rect="0,0,20,20">
+                                            <RectangleGeometry.Transform>
+                                                <TranslateTransform x:Name="MultiSelectClipTransform" />
+                                            </RectangleGeometry.Transform>
+                                        </RectangleGeometry>
+                                    </Border.Clip>
+                                    <Border.RenderTransform>
+                                        <TranslateTransform x:Name="MultiSelectCheckBoxTransform" />
+                                    </Border.RenderTransform>
+                                    <FontIcon
+                                        x:Name="MultiSelectCheck"
+                                        FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                        FontSize="16"
+                                        Foreground="{ThemeResource SystemControlForegroundBaseMediumHighBrush}"
+                                        Glyph="&#xE73E;"
+                                        Opacity="0"
+                                        Visibility="Collapsed" />
+                                </Border>
+                                <Border
+                                    x:Name="MultiArrangeOverlayTextBorder"
+                                    Height="20"
+                                    MinWidth="20"
+                                    Margin="12,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Center"
+                                    Background="{ThemeResource SystemControlBackgroundAccentBrush}"
+                                    BorderBrush="{ThemeResource SystemControlBackgroundChromeWhiteBrush}"
+                                    BorderThickness="2"
+                                    IsHitTestVisible="False"
+                                    Opacity="0">
+                                    <TextBlock
+                                        x:Name="MultiArrangeOverlayText"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        AutomationProperties.AccessibilityView="Raw"
+                                        IsHitTestVisible="False"
+                                        Opacity="0"
+                                        Style="{ThemeResource CaptionTextBlockStyle}"
+                                        Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=TemplateSettings.DragItemsCount}" />
+                                </Border>
+
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Normal">
+
+                                            <Storyboard>
+                                                <PointerUpThemeAnimation Storyboard.TargetName="ContentPresenter" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="PointerOver">
+
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="BorderBackground"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="0.6"
+                                                    Duration="0" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderBackground" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightListLowBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectSquare" Storyboard.TargetProperty="BorderBrush">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectCheck" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <PointerUpThemeAnimation Storyboard.TargetName="ContentPresenter" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="Pressed">
+
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="BorderBackground"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="0.6"
+                                                    Duration="0" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderBackground" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightListLowBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectSquare" Storyboard.TargetProperty="BorderBrush">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectCheck" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <PointerDownThemeAnimation TargetName="ContentPresenter" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="Selected">
+
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiSelectCheck"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="1"
+                                                    Duration="0:0:0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="BorderBackground"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="0.6"
+                                                    Duration="0" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderBackground" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightListLowBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderSelected" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AccentFillColorDefaultBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectSquare" Storyboard.TargetProperty="BorderBrush">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectCheck" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <PointerUpThemeAnimation Storyboard.TargetName="ContentPresenter" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="PointerOverSelected">
+
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiSelectCheck"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="1"
+                                                    Duration="0:0:0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="BorderBackground"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="0.5"
+                                                    Duration="0" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderBackground" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightListMediumBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderSelected" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AccentFillColorDefaultBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectSquare" Storyboard.TargetProperty="BorderBrush">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectCheck" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <PointerUpThemeAnimation Storyboard.TargetName="ContentPresenter" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="PressedSelected">
+
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiSelectCheck"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="1"
+                                                    Duration="0:0:0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="BorderBackground"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="0.6"
+                                                    Duration="0" />
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderBackground" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightListMediumBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderSelected" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AccentFillColorDefaultBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectSquare" Storyboard.TargetProperty="BorderBrush">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectCheck" Storyboard.TargetProperty="Foreground">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemControlHighlightAltBaseHighBrush}" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <PointerDownThemeAnimation TargetName="ContentPresenter" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                    </VisualStateGroup>
+
+                                    <VisualStateGroup x:Name="DisabledStates">
+                                        <VisualState x:Name="Enabled" />
+
+                                        <VisualState x:Name="Disabled">
+
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="ContentBorder"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="{ThemeResource ListViewItemDisabledThemeOpacity}"
+                                                    Duration="0" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                    </VisualStateGroup>
+
+                                    <VisualStateGroup x:Name="MultiSelectStates">
+                                        <VisualState x:Name="MultiSelectDisabled">
+
+                                            <Storyboard>
+                                                <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectCheckBoxTransform" Storyboard.TargetProperty="X">
+                                                    <EasingDoubleKeyFrame KeyTime="0:0:0" Value="0" />
+                                                    <SplineDoubleKeyFrame
+                                                        KeySpline="0.1,0.9,0.2,1"
+                                                        KeyTime="0:0:0.333"
+                                                        Value="-32" />
+                                                </DoubleAnimationUsingKeyFrames>
+                                                <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectClipTransform" Storyboard.TargetProperty="X">
+                                                    <EasingDoubleKeyFrame KeyTime="0:0:0" Value="0" />
+                                                    <SplineDoubleKeyFrame
+                                                        KeySpline="0.1,0.9,0.2,1"
+                                                        KeyTime="0:0:0.333"
+                                                        Value="32" />
+                                                </DoubleAnimationUsingKeyFrames>
+                                                <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterTranslateTransform" Storyboard.TargetProperty="X">
+                                                    <EasingDoubleKeyFrame KeyTime="0:0:0" Value="32" />
+                                                    <SplineDoubleKeyFrame
+                                                        KeySpline="0.1,0.9,0.2,1"
+                                                        KeyTime="0:0:0.333"
+                                                        Value="0" />
+                                                </DoubleAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectSquare" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
+                                                    <DiscreteObjectKeyFrame KeyTime="0:0:0.333" Value="Collapsed" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="MultiSelectEnabled">
+
+                                            <Storyboard>
+                                                <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectCheckBoxTransform" Storyboard.TargetProperty="X">
+                                                    <EasingDoubleKeyFrame KeyTime="0:0:0" Value="-32" />
+                                                    <SplineDoubleKeyFrame
+                                                        KeySpline="0.1,0.9,0.2,1"
+                                                        KeyTime="0:0:0.333"
+                                                        Value="0" />
+                                                </DoubleAnimationUsingKeyFrames>
+                                                <DoubleAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectClipTransform" Storyboard.TargetProperty="X">
+                                                    <EasingDoubleKeyFrame KeyTime="0:0:0" Value="32" />
+                                                    <SplineDoubleKeyFrame
+                                                        KeySpline="0.1,0.9,0.2,1"
+                                                        KeyTime="0:0:0.333"
+                                                        Value="0" />
+                                                </DoubleAnimationUsingKeyFrames>
+                                                <DoubleAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterTranslateTransform" Storyboard.TargetProperty="X">
+                                                    <EasingDoubleKeyFrame KeyTime="0:0:0" Value="-32" />
+                                                    <SplineDoubleKeyFrame
+                                                        KeySpline="0.1,0.9,0.2,1"
+                                                        KeyTime="0:0:0.333"
+                                                        Value="0" />
+                                                </DoubleAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectSquare" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="MultiSelectCheck" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenterGrid" Storyboard.TargetProperty="Margin">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="32,0,0,0" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                            </Storyboard>
+                                        </VisualState>
+
+                                    </VisualStateGroup>
+
+                                    <VisualStateGroup x:Name="DataVirtualizationStates">
+                                        <VisualState x:Name="DataAvailable" />
+
+                                        <VisualState x:Name="DataPlaceholder">
+
+                                            <Storyboard>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextBlock" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderRect" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="Visible" />
+                                                </ObjectAnimationUsingKeyFrames>
+                                            </Storyboard>
+                                        </VisualState>
+
+                                    </VisualStateGroup>
+
+                                    <VisualStateGroup x:Name="ReorderHintStates">
+                                        <VisualState x:Name="NoReorderHint" />
+
+                                        <VisualState x:Name="BottomReorderHint">
+
+                                            <Storyboard>
+                                                <DragOverThemeAnimation
+                                                    Direction="Bottom"
+                                                    ToOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
+                                                    TargetName="ContentBorder" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="TopReorderHint">
+
+                                            <Storyboard>
+                                                <DragOverThemeAnimation
+                                                    Direction="Top"
+                                                    ToOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
+                                                    TargetName="ContentBorder" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="RightReorderHint">
+
+                                            <Storyboard>
+                                                <DragOverThemeAnimation
+                                                    Direction="Right"
+                                                    ToOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
+                                                    TargetName="ContentBorder" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="LeftReorderHint">
+
+                                            <Storyboard>
+                                                <DragOverThemeAnimation
+                                                    Direction="Left"
+                                                    ToOffset="{ThemeResource ListViewItemReorderHintThemeOffset}"
+                                                    TargetName="ContentBorder" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualStateGroup.Transitions>
+                                            <VisualTransition GeneratedDuration="0:0:0.2" To="NoReorderHint" />
+                                        </VisualStateGroup.Transitions>
+
+                                    </VisualStateGroup>
+
+                                    <VisualStateGroup x:Name="DragStates">
+                                        <VisualState x:Name="NotDragging" />
+
+                                        <VisualState x:Name="Dragging">
+
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="ContentBorder"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="{ThemeResource ListViewItemDragThemeOpacity}"
+                                                    Duration="0" />
+                                                <DragItemThemeAnimation TargetName="ContentBorder" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="DraggingTarget" />
+
+                                        <VisualState x:Name="MultipleDraggingPrimary">
+
+                                            <Storyboard>
+                                                <!--
+                                                    These two Opacity animations are required - the FadeInThemeAnimations
+                                                    on the same elements animate an internal Opacity.
+                                                -->
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiArrangeOverlayText"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="1"
+                                                    Duration="0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiArrangeOverlayTextBorder"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="1"
+                                                    Duration="0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiSelectSquare"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="0"
+                                                    Duration="0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiSelectCheck"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="0"
+                                                    Duration="0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="ContentBorder"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="{ThemeResource ListViewItemDragThemeOpacity}"
+                                                    Duration="0" />
+                                                <FadeInThemeAnimation TargetName="MultiArrangeOverlayText" />
+                                                <FadeInThemeAnimation TargetName="MultiArrangeOverlayTextBorder" />
+                                                <DragItemThemeAnimation TargetName="ContentBorder" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="MultipleDraggingSecondary" />
+
+                                        <VisualState x:Name="DraggedPlaceholder" />
+
+                                        <VisualState x:Name="Reordering">
+
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="ContentBorder"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="{ThemeResource ListViewItemReorderThemeOpacity}"
+                                                    Duration="0:0:0.240" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="ReorderingTarget">
+
+                                            <Storyboard>
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="ContentBorder"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="{ThemeResource ListViewItemReorderTargetThemeOpacity}"
+                                                    Duration="0:0:0.240" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="ContentBorderScale"
+                                                    Storyboard.TargetProperty="ScaleX"
+                                                    To="{ThemeResource ListViewItemReorderTargetThemeScale}"
+                                                    Duration="0:0:0.240" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="ContentBorderScale"
+                                                    Storyboard.TargetProperty="ScaleY"
+                                                    To="{ThemeResource ListViewItemReorderTargetThemeScale}"
+                                                    Duration="0:0:0.240" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="MultipleReorderingPrimary">
+
+                                            <Storyboard>
+                                                <!--
+                                                    These two Opacity animations are required - the FadeInThemeAnimations
+                                                    on the same elements animate an internal Opacity.
+                                                -->
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiArrangeOverlayText"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="1"
+                                                    Duration="0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiArrangeOverlayTextBorder"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="1"
+                                                    Duration="0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiSelectSquare"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="0"
+                                                    Duration="0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="MultiSelectCheck"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="0"
+                                                    Duration="0" />
+                                                <DoubleAnimation
+                                                    Storyboard.TargetName="ContentBorder"
+                                                    Storyboard.TargetProperty="Opacity"
+                                                    To="{ThemeResource ListViewItemDragThemeOpacity}"
+                                                    Duration="0:0:0.240" />
+                                                <FadeInThemeAnimation TargetName="MultiArrangeOverlayText" />
+                                                <FadeInThemeAnimation TargetName="MultiArrangeOverlayTextBorder" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="ReorderedPlaceholder">
+
+                                            <Storyboard>
+                                                <FadeOutThemeAnimation TargetName="ContentBorder" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="DragOver">
+
+                                            <Storyboard>
+                                                <DropTargetItemThemeAnimation TargetName="ContentBorder" />
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualStateGroup.Transitions>
+                                            <VisualTransition GeneratedDuration="0:0:0.2" To="NotDragging" />
+                                        </VisualStateGroup.Transitions>
+
+                                    </VisualStateGroup>
+
+                                </VisualStateManager.VisualStateGroups>
+                            </Grid>
+
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Default">
                     <SolidColorBrush x:Key="CardBackgroundBrush" Color="#10ffffff" />

--- a/src/Drizzle.UI.UWP/App.xaml
+++ b/src/Drizzle.UI.UWP/App.xaml
@@ -721,13 +721,12 @@
                 <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
                 <Setter Property="TabNavigation" Value="Local" />
                 <Setter Property="IsHoldingEnabled" Value="True" />
-                <Setter Property="Padding" Value="12,0,12,0" />
+                <Setter Property="Padding" Value="12,-2" />
                 <Setter Property="Margin" Value="4,2" />
                 <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                 <Setter Property="VerticalContentAlignment" Value="Center" />
                 <Setter Property="MinWidth" Value="{ThemeResource ListViewItemMinWidth}" />
                 <Setter Property="MinHeight" Value="{ThemeResource ListViewItemMinHeight}" />
-                <Setter Property="MaxWidth" Value="1224" />
                 <Setter Property="AllowDrop" Value="False" />
                 <Setter Property="UseSystemFocusVisuals" Value="{StaticResource UseSystemFocusVisuals}" />
                 <Setter Property="FocusVisualMargin" Value="0" />

--- a/src/Drizzle.UI.UWP/Views/MainPage.xaml
+++ b/src/Drizzle.UI.UWP/Views/MainPage.xaml
@@ -193,6 +193,7 @@
                     </Border.Background>
                     <!--  x:Bind have bug here, ref:  -->
                     <ListView
+                        ItemContainerStyle="{ThemeResource ListViewItemStyle}"
                         Padding="0,2,0,2"
                         Background="{ThemeResource CardBackgroundBrush}"
                         ItemsSource="{Binding SelectedLocation.Daily, Mode=OneWay}"


### PR DESCRIPTION
Fix #54 .

![image](https://github.com/rocksdanister/weather/assets/96322503/043ebd6b-9cb6-4e84-9e69-e4a2679e5833)
`ListView` will use the system's `ItemContainerStyle`, but this will cause exceptions on Windows 10.

For example, in Windows 11, `HorizontalContentAlignment` is set to `Stretch`, but on Windows 10 it is `Left`, which results in the issue

I rewrote this style to fix it, and we can apply `ItemContainerStyle="{ThemeResource ListViewItemStyle}"` to solve the same problem in other `ListView`

